### PR TITLE
Strip thematic breaks

### DIFF
--- a/src/pages/posts/[year]/[month]/[day]/[slug].tsx
+++ b/src/pages/posts/[year]/[month]/[day]/[slug].tsx
@@ -135,6 +135,7 @@ const getStaticProps: GetStaticProps<Props> = async (ctx) => {
                         ),
                     ]);
                 },
+                thematicBreak: () => undefined,
             },
         })
         .use(rehypeKatex, { strict: true })


### PR DESCRIPTION
They are used just for indicating the preface
